### PR TITLE
Point release to fix deprecation breakage introduced by matplotlib

### DIFF
--- a/Owlcat/Plotting.py
+++ b/Owlcat/Plotting.py
@@ -202,8 +202,17 @@ class PlotCollection(object):
         if suptitle:
             fig.suptitle(suptitle, y=ytitle, size=8)
         if save:
-            fig.savefig(save, papertype=papertype, dpi=dpi,
-                        orientation='portrait' if not landscape else 'landscape')
+            dicokwargs = {
+                "papertype": papertype,
+                "dpi": dpi,
+                "orientation": 'portrait' if not landscape else 'landscape',
+            }
+            # fix for matplotlib becoming stricter on papertype
+            if matplotlib.get_backend() != "ps":
+                del dicokwargs["papertype"]
+                del dicokwargs["orientation"]
+
+            fig.savefig(save, **dicokwargs)
             print("===> Wrote", save)
         return fig
 
@@ -494,8 +503,16 @@ class ScatterPlot(object):
         if suptitle:
             fig.suptitle(suptitle, y=ytitle, size=10)
         if save:
-            fig.savefig(save, papertype=papertype, dpi=dpi,
-                        orientation='portrait' if not landscape else 'landscape')
+            dicokwargs = {
+                "papertype": papertype,
+                "dpi": dpi,
+                "orientation": 'portrait' if not landscape else 'landscape',
+            }
+            # fix for matplotlib becoming stricter on papertype
+            if matplotlib.get_backend() != "ps":
+                del dicokwargs["papertype"]
+                del dicokwargs["orientation"]
+            fig.savefig(save, **dicokwargs)
             print("===> Wrote", save)
         return fig
 
@@ -810,8 +827,17 @@ class MultigridPlot(AbstractBasePlot):
                 orientation = 'landscape'
             else:
                 orientation = 'portrait' if figsize[0] < figsize[1] else 'landscape'
-            fig.savefig(save, papertype=self.options.papertype, dpi=self.options.dpi,
-                        orientation=orientation)
+            dicokwargs = {
+                "papertype": self.options.papertype,
+                "dpi": self.options.dpi,
+                "orientation": orientation,
+            }
+            # fix for matplotlib becoming stricter on papertype
+            if matplotlib.get_backend() != "ps":
+                del dicokwargs["papertype"]
+                del dicokwargs["orientation"]
+            
+            fig.savefig(save, **dicokwargs)
             print("Wrote", save, "in", orientation, "orientation")
             fig = None
             pyplot.close("all")
@@ -965,8 +991,17 @@ class SkyPlot(AbstractBasePlot):
                 orientation = 'landscape'
             else:
                 orientation = 'portrait' if figsize[0] < figsize[1] else 'landscape'
-            fig.savefig(save, papertype=self.options.papertype, dpi=self.options.dpi,
-                        orientation=orientation)
+            dicokwargs = {
+                "papertype": self.options.papertype,
+                "dpi": self.options.dpi,
+                "orientation": orientation,
+            }
+            # fix for matplotlib becoming stricter on papertype
+            if matplotlib.get_backend() != "ps":
+                del dicokwargs["papertype"]
+                del dicokwargs["orientation"]
+            
+            fig.savefig(save, **dicokwargs)
             print("Wrote", save, "in", orientation, "orientation")
             fig = None
             pyplot.close("all")
@@ -1137,8 +1172,17 @@ class LSTElevationPlot(AbstractBasePlot):
                 orientation = 'landscape'
             else:
                 orientation = 'portrait' if figsize[0] < figsize[1] else 'landscape'
-            fig.savefig(save, papertype=self.options.papertype, dpi=self.options.dpi,
-                        orientation=orientation)
+            dicokwargs = {
+                "papertype": self.options.papertype,
+                "dpi": self.options.dpi,
+                "orientation": orientation,
+            }
+            # fix for matplotlib becoming stricter on papertype
+            if matplotlib.get_backend() != "ps":
+                del dicokwargs["papertype"]
+                del dicokwargs["orientation"]
+
+            fig.savefig(save, **dicokwargs)
             print("Wrote", save, "in", orientation, "orientation")
             fig = None
             pyplot.close("all")

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 ]
 
 setup(name='owlcat',
-      version='1.7.8.3',
+      version='1.7.8.4',
       python_requires='>=3.6.0',
       description='miscellaneous utility scripts for manipulating radio interferometry data',
       author='Oleg Smirnov',


### PR DESCRIPTION
Matplotlib 3.6.0 introduces breaking deprecation on writeout of non-ps backend plots specifying papertype and orientation

This only shows for code paths using Python 3.8